### PR TITLE
Expose dragged-over index for DRAGGED_OVER_INDEX

### DIFF
--- a/src/pointerAction.js
+++ b/src/pointerAction.js
@@ -207,7 +207,7 @@ function handleDraggedIsOverIndex(e) {
     const shadowElIdx = findShadowElementIdx(items);
     items.splice(shadowElIdx, 1);
     items.splice(index, 0, shadowElData);
-    dispatchConsiderEvent(e.currentTarget, items, {trigger: TRIGGERS.DRAGGED_OVER_INDEX, id: draggedElData[ITEM_ID_KEY], source: SOURCES.POINTER});
+    dispatchConsiderEvent(e.currentTarget, items, {trigger: TRIGGERS.DRAGGED_OVER_INDEX, id: draggedElData[ITEM_ID_KEY], source: SOURCES.POINTER, index});
 }
 
 // Global mouse/touch-events handlers


### PR DESCRIPTION
Previously, the DRAGGED_OVER_INDEX event didn't actually expose the index of the item which the dragged-item was dragged over. Now it does.